### PR TITLE
Allow cluster versions like 1.23

### DIFF
--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -66,7 +66,7 @@ func SemVer(version string) error {
 	if version == "" {
 		return errors.New("version is empty")
 	}
-	exp := `^\d+\.\d+\.\d+$`
+	exp := `^\d+\.\d+(?:\.\d+)?$`
 	r := regexp.MustCompile(exp)
 	if !r.MatchString(version) {
 		return fmt.Errorf("invalid version. valid version is of: %s", exp)

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -218,7 +218,8 @@ func TestSemVer(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{"ok", args{"1.2.3"}, false},
+		{"ok 1", args{"1.2.3"}, false},
+		{"ok 2", args{"1.2"}, false},
 		{"not ok 1", args{"ab1.2.3"}, true},
 		{"not ok 2", args{""}, true},
 	}


### PR DESCRIPTION
Addresses issue 18 of the terraform provider.
This makes the terraform provider's acceptance tests like brittle, as they don't have to be updated when only the cluster's patch version changes.