### PR TITLE
Modify Retry & Wait packages + provide first usage example

### DIFF
--- a/client.go
+++ b/client.go
@@ -54,7 +54,7 @@ func New(ctx context.Context, cfg *Config) (*Client, error) {
 	c := &Client{
 		config: cfg,
 		ctx:    ctx,
-		retry:  retry.New(),
+		retry:  nil,
 	}
 	return c.init(), nil
 }

--- a/client.go
+++ b/client.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/SchwarzIT/community-stackit-go-client/internal/common"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/api/v1/argus"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/api/v1/costs"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/api/v1/kubernetes"
@@ -55,22 +54,9 @@ func New(ctx context.Context, cfg *Config) (*Client, error) {
 	c := &Client{
 		config: cfg,
 		ctx:    ctx,
+		retry:  retry.New(),
 	}
 	return c.init(), nil
-}
-
-// WithRetry sets retry.Retry in a shallow copy of the given client
-// and returns the new copy after init re-run
-func (c *Client) WithRetry(r *retry.Retry) common.Client {
-	nc := *c
-	nc.retry = r
-	p := &nc
-	return p.init()
-}
-
-// GetRetry returns the defined retry
-func (c *Client) GetRetry() *retry.Retry {
-	return c.retry
 }
 
 // Service management
@@ -201,6 +187,16 @@ func (c *Client) do(req *http.Request, v interface{}, errorHandlers ...func(*htt
 // OrganizationID returns the organization ID defined in the configuration
 func (c *Client) OrganizationID() string {
 	return c.config.OrganizationID
+}
+
+// Retry returns the defined retry
+func (c *Client) Retry() *retry.Retry {
+	return c.retry
+}
+
+// SetRetry overrides default retry setting
+func (c *Client) SetRetry(r *retry.Retry) {
+	c.retry = r
 }
 
 // MockServer mocks STACKIT api server

--- a/client.go
+++ b/client.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/SchwarzIT/community-stackit-go-client/internal/common"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/api/v1/argus"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/api/v1/costs"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/api/v1/kubernetes"
@@ -60,11 +61,16 @@ func New(ctx context.Context, cfg *Config) (*Client, error) {
 
 // WithRetry sets retry.Retry in a shallow copy of the given client
 // and returns the new copy after init re-run
-func (c *Client) WithRetry(r *retry.Retry) *Client {
+func (c *Client) WithRetry(r *retry.Retry) common.Client {
 	nc := *c
 	nc.retry = r
 	p := &nc
 	return p.init()
+}
+
+// GetRetry returns the defined retry
+func (c *Client) GetRetry() *retry.Retry {
+	return c.retry
 }
 
 // Service management

--- a/client_test.go
+++ b/client_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/consts"
+	"github.com/SchwarzIT/community-stackit-go-client/pkg/retry"
 )
 
 func TestNew(t *testing.T) {
@@ -285,6 +286,7 @@ func TestClient_DoWithRetryNonRetryableError(t *testing.T) {
 		t.Errorf("error from mock.AuthServer: %s", err.Error())
 	}
 
+	c.SetRetry(retry.New())
 	c.Retry().SetThrottle(1 * time.Second)
 
 	mux.HandleFunc("/err", func(w http.ResponseWriter, r *http.Request) {

--- a/client_test.go
+++ b/client_test.go
@@ -9,9 +9,9 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/consts"
-	"github.com/SchwarzIT/community-stackit-go-client/pkg/retry"
 )
 
 func TestNew(t *testing.T) {
@@ -109,6 +109,8 @@ func TestClient_Do(t *testing.T) {
 	if err != nil {
 		t.Errorf("error from mock.AuthServer: %s", err.Error())
 	}
+
+	c.SetRetry(nil)
 
 	mux.HandleFunc("/echo", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -283,13 +285,15 @@ func TestClient_DoWithRetryNonRetryableError(t *testing.T) {
 		t.Errorf("error from mock.AuthServer: %s", err.Error())
 	}
 
+	c.Retry().SetThrottle(1 * time.Second)
+
 	mux.HandleFunc("/err", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 	})
 
 	req, _ := c.Request(context.Background(), http.MethodGet, "/err", nil)
-	if _, err := c.WithRetry(retry.New()).Do(req, nil); err == nil {
+	if _, err := c.Do(req, nil); err == nil {
 		t.Error("expected do request to return error but got nil instead")
 	}
 }

--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -6,12 +6,16 @@ package common
 import (
 	"context"
 	"net/http"
+
+	"github.com/SchwarzIT/community-stackit-go-client/pkg/retry"
 )
 
 // Client is the client interface
 type Client interface {
 	Request(ctx context.Context, method, path string, body []byte) (*http.Request, error)
 	Do(req *http.Request, v interface{}, errorHandlers ...func(*http.Response) error) (*http.Response, error)
+	WithRetry(r *retry.Retry) Client
+	GetRetry() *retry.Retry
 	OrganizationID() string
 }
 

--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -14,8 +14,7 @@ import (
 type Client interface {
 	Request(ctx context.Context, method, path string, body []byte) (*http.Request, error)
 	Do(req *http.Request, v interface{}, errorHandlers ...func(*http.Response) error) (*http.Response, error)
-	WithRetry(r *retry.Retry) Client
-	GetRetry() *retry.Retry
+	Retry() *retry.Retry
 	OrganizationID() string
 }
 

--- a/pkg/api/v1/kubernetes/projects/project.go
+++ b/pkg/api/v1/kubernetes/projects/project.go
@@ -66,6 +66,9 @@ func (svc *KubernetesProjectsService) waitForCreation(ctx context.Context, proje
 	return func() (res interface{}, done bool, err error) {
 		res, err = svc.Get(ctx, projectID)
 		if err != nil {
+			if strings.Contains(err.Error(), "project has no assigned namespace") {
+				return nil, false, nil
+			}
 			return nil, false, err
 		}
 		project := res.(KubernetesProjectsResponse)

--- a/pkg/api/v1/kubernetes/projects/project.go
+++ b/pkg/api/v1/kubernetes/projects/project.go
@@ -57,12 +57,12 @@ func (svc *KubernetesProjectsService) Create(ctx context.Context, projectID stri
 	}
 
 	_, err = svc.Client.Do(req, &res)
-	w = wait.New(svc.createWait(ctx, projectID))
+	w = wait.New(svc.waitForCreation(ctx, projectID))
 	return
 }
 
-// createWait returns a wait function to determine if kubernetes project has been created
-func (svc *KubernetesProjectsService) createWait(ctx context.Context, projectID string) wait.WaitFn {
+// waitForCreation returns a wait function to determine if kubernetes project has been created
+func (svc *KubernetesProjectsService) waitForCreation(ctx context.Context, projectID string) wait.WaitFn {
 	return func() (res interface{}, done bool, err error) {
 		res, err = svc.Get(ctx, projectID)
 		if err != nil {
@@ -95,12 +95,12 @@ func (svc *KubernetesProjectsService) Delete(ctx context.Context, projectID stri
 	}
 
 	_, err = svc.Client.Do(req, nil)
-	w = wait.New(svc.deleteWait(ctx, projectID))
+	w = wait.New(svc.waitForDeletion(ctx, projectID))
 	return
 }
 
-// deleteWait returns a wait function to determine if kubernetes project has been deleted
-func (svc *KubernetesProjectsService) deleteWait(ctx context.Context, projectID string) wait.WaitFn {
+// waitForDeletion returns a wait function to determine if kubernetes project has been deleted
+func (svc *KubernetesProjectsService) waitForDeletion(ctx context.Context, projectID string) wait.WaitFn {
 	return func() (res interface{}, done bool, err error) {
 		res, err = svc.Get(ctx, projectID)
 		if err != nil {

--- a/pkg/api/v1/kubernetes/projects/project.go
+++ b/pkg/api/v1/kubernetes/projects/project.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/SchwarzIT/community-stackit-go-client/internal/common"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/consts"
+	"github.com/SchwarzIT/community-stackit-go-client/pkg/wait"
 )
 
 // constants
@@ -48,25 +50,65 @@ func (svc *KubernetesProjectsService) Get(ctx context.Context, projectID string)
 
 // Create creates an SKE project
 // See also https://api.stackit.schwarz/ske-service/openapi.v1.html#operation/SkeService_GetProject
-func (svc *KubernetesProjectsService) Create(ctx context.Context, projectID string) (res KubernetesProjectsResponse, err error) {
+func (svc *KubernetesProjectsService) Create(ctx context.Context, projectID string) (res KubernetesProjectsResponse, w *wait.Handler, err error) {
 	req, err := svc.Client.Request(ctx, http.MethodPut, fmt.Sprintf(apiPath, projectID), nil)
 	if err != nil {
 		return
 	}
 
 	_, err = svc.Client.Do(req, &res)
+	w = wait.New(svc.createWait(ctx, projectID))
 	return
+}
+
+// createWait returns a wait function to determine if kubernetes project has been created
+func (svc *KubernetesProjectsService) createWait(ctx context.Context, projectID string) wait.WaitFn {
+	return func() (res interface{}, done bool, err error) {
+		res, err = svc.Get(ctx, projectID)
+		if err != nil {
+			return nil, false, err
+		}
+		project := res.(KubernetesProjectsResponse)
+		switch project.State {
+		case consts.SKE_PROJECT_STATUS_FAILED:
+			fallthrough
+		case consts.SKE_PROJECT_STATUS_DELETING:
+			err = fmt.Errorf("received state: %s for project ID: %s",
+				project.State,
+				project.ProjectID,
+			)
+			return
+		case consts.SKE_PROJECT_STATUS_CREATED:
+			return nil, true, nil
+		}
+		return nil, false, nil
+	}
 }
 
 // Delete deletes an SKE project
 // IMPORTANT: existing clusters to be automatically deleted
 // See also https://api.stackit.schwarz/ske-service/openapi.v1.html#operation/SkeService_GetProject
-func (svc *KubernetesProjectsService) Delete(ctx context.Context, projectID string) (err error) {
+func (svc *KubernetesProjectsService) Delete(ctx context.Context, projectID string) (w *wait.Handler, err error) {
 	req, err := svc.Client.Request(ctx, http.MethodDelete, fmt.Sprintf(apiPath, projectID), nil)
 	if err != nil {
 		return
 	}
 
 	_, err = svc.Client.Do(req, nil)
+	w = wait.New(svc.deleteWait(ctx, projectID))
 	return
+}
+
+// deleteWait returns a wait function to determine if kubernetes project has been deleted
+func (svc *KubernetesProjectsService) deleteWait(ctx context.Context, projectID string) wait.WaitFn {
+	return func() (res interface{}, done bool, err error) {
+		res, err = svc.Get(ctx, projectID)
+		if err != nil {
+			if strings.Contains(err.Error(), http.StatusText(http.StatusNotFound)) {
+				return nil, true, nil
+			}
+			return nil, false, err
+		}
+		return nil, false, nil
+	}
 }

--- a/pkg/api/v1/kubernetes/projects/project_test.go
+++ b/pkg/api/v1/kubernetes/projects/project_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/SchwarzIT/community-stackit-go-client"
+	client "github.com/SchwarzIT/community-stackit-go-client"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/api/v1/kubernetes"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/api/v1/kubernetes/projects"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/consts"
@@ -110,7 +110,7 @@ func TestKubernetesProjectsService_Create(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := s.Projects.Create(tt.args.ctx, tt.args.projectID)
+			gotRes, _, err := s.Projects.Create(tt.args.ctx, tt.args.projectID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("KubernetesProjectsService.Create() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -156,7 +156,7 @@ func TestKubernetesProjectsService_Delete(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := s.Projects.Delete(tt.args.ctx, tt.args.projectID); (err != nil) != tt.wantErr {
+			if _, err := s.Projects.Delete(tt.args.ctx, tt.args.projectID); (err != nil) != tt.wantErr {
 				t.Errorf("KubernetesProjectsService.Delete() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/api/v1/kubernetes/projects/project_test.go
+++ b/pkg/api/v1/kubernetes/projects/project_test.go
@@ -7,11 +7,13 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 
 	client "github.com/SchwarzIT/community-stackit-go-client"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/api/v1/kubernetes"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/api/v1/kubernetes/projects"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/consts"
+	"github.com/SchwarzIT/community-stackit-go-client/pkg/wait"
 )
 
 func TestKubernetesProjectsService_Get(t *testing.T) {
@@ -80,15 +82,56 @@ func TestKubernetesProjectsService_Create(t *testing.T) {
 		State:     consts.SKE_PROJECT_STATUS_UNSPECIFIED,
 	}
 
-	mux.HandleFunc("/ske/v1/projects/"+projectID, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut {
-			t.Error("wrong method")
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
+	ctx2, cancel2 := context.WithTimeout(context.TODO(), 1*time.Second)
+	defer cancel2()
 
-		b, _ := json.Marshal(want)
-		fmt.Fprint(w, string(b))
+	ctx3, cancel3 := context.WithTimeout(context.TODO(), 3*time.Second)
+	defer cancel3()
+
+	state1 := projects.KubernetesProjectsResponse{
+		ProjectID: projectID,
+		State:     consts.SKE_PROJECT_STATUS_UNSPECIFIED,
+	}
+
+	state2 := projects.KubernetesProjectsResponse{
+		ProjectID: projectID,
+		State:     consts.SKE_PROJECT_STATUS_CREATED,
+	}
+
+	state3 := projects.KubernetesProjectsResponse{
+		ProjectID: projectID,
+		State:     consts.SKE_PROJECT_STATUS_FAILED,
+	}
+
+	mux.HandleFunc("/ske/v1/projects/"+projectID, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			b, _ := json.Marshal(want)
+			fmt.Fprint(w, string(b))
+			return
+		}
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			if ctx2.Err() == nil {
+				b, _ := json.Marshal(state1)
+				fmt.Fprint(w, string(b))
+				return
+			}
+			if ctx3.Err() == nil {
+				b, _ := json.Marshal(state2)
+				fmt.Fprint(w, string(b))
+				return
+			}
+
+			b, _ := json.Marshal(state3)
+			fmt.Fprint(w, string(b))
+			return
+		}
+		t.Error("wrong method")
 	})
 
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -99,18 +142,21 @@ func TestKubernetesProjectsService_Create(t *testing.T) {
 		projectID string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantRes projects.KubernetesProjectsResponse
-		wantErr bool
+		name     string
+		args     args
+		wantRes  projects.KubernetesProjectsResponse
+		wantErr  bool
+		goodWait bool
 	}{
-		{"all ok", args{context.Background(), projectID}, want, false},
-		{"ctx is canceled", args{ctx, projectID}, want, true},
-		{"project not found", args{context.Background(), "my-project"}, want, true},
+		{"all ok", args{context.Background(), projectID}, want, false, true},
+		{"ctx is canceled", args{ctx, projectID}, want, true, false},
+		{"project not found", args{context.Background(), "my-project"}, want, true, false},
 	}
+
+	var goodWait, badWait *wait.Handler
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, _, err := s.Projects.Create(tt.args.ctx, tt.args.projectID)
+			gotRes, w, err := s.Projects.Create(tt.args.ctx, tt.args.projectID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("KubernetesProjectsService.Create() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -118,8 +164,30 @@ func TestKubernetesProjectsService_Create(t *testing.T) {
 			if !reflect.DeepEqual(gotRes, tt.wantRes) && !tt.wantErr {
 				t.Errorf("KubernetesProjectsService.Create() = %v, want %v", gotRes, tt.wantRes)
 			}
+			if tt.goodWait {
+				goodWait = w
+			} else {
+				badWait = w
+			}
 		})
 	}
+
+	c.SetRetry(nil)
+	goodWait.SetThrottle(20 * time.Millisecond)
+	badWait.SetThrottle(20 * time.Millisecond)
+
+	if _, err := goodWait.Wait(); err != nil {
+		t.Errorf("returned: %v", err)
+	}
+	if _, err := badWait.Wait(); err == nil {
+		t.Error("expected error but got nil")
+	}
+
+	time.Sleep(2 * time.Second)
+	if _, err := goodWait.Wait(); err == nil {
+		t.Error("expected error but got nil [2]")
+	}
+
 }
 
 func TestKubernetesProjectsService_Delete(t *testing.T) {
@@ -129,36 +197,87 @@ func TestKubernetesProjectsService_Delete(t *testing.T) {
 
 	projectID := "5dae0612-f5b1-4615-b7ca-b18796aa7e78"
 
-	mux.HandleFunc("/ske/v1/projects/"+projectID, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete {
-			t.Error("wrong method")
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-
-	})
-
 	ctx, cancel := context.WithCancel(context.TODO())
 	cancel()
+
+	ctx2, cancel2 := context.WithTimeout(context.TODO(), 1*time.Second)
+	defer cancel2()
+
+	ctx3, cancel3 := context.WithTimeout(context.TODO(), 3*time.Second)
+	defer cancel3()
+
+	state1 := projects.KubernetesProjectsResponse{
+		ProjectID: projectID,
+		State:     consts.SKE_PROJECT_STATUS_DELETING,
+	}
+
+	mux.HandleFunc("/ske/v1/projects/"+projectID, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+
+			if ctx2.Err() == nil {
+				w.WriteHeader(http.StatusOK)
+				b, _ := json.Marshal(state1)
+				fmt.Fprint(w, string(b))
+				return
+			}
+
+			if ctx3.Err() == nil {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		t.Error("wrong method")
+	})
 
 	type args struct {
 		ctx       context.Context
 		projectID string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name     string
+		args     args
+		wantErr  bool
+		goodWait bool
 	}{
-		{"all ok", args{context.Background(), projectID}, false},
-		{"ctx is canceled", args{ctx, projectID}, true},
-		{"project not found", args{context.Background(), "my-project"}, true},
+		{"all ok", args{context.Background(), projectID}, false, true},
+		{"ctx is canceled", args{ctx, projectID}, true, false},
+		{"project not found", args{context.Background(), "my-project"}, true, false},
 	}
+
+	var goodWait, badWait *wait.Handler
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := s.Projects.Delete(tt.args.ctx, tt.args.projectID); (err != nil) != tt.wantErr {
+			w, err := s.Projects.Delete(tt.args.ctx, tt.args.projectID)
+			if (err != nil) != tt.wantErr {
 				t.Errorf("KubernetesProjectsService.Delete() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.goodWait {
+				goodWait = w
+			} else {
+				badWait = w
 			}
 		})
 	}
+
+	c.SetRetry(nil)
+	goodWait.SetThrottle(20 * time.Millisecond)
+	badWait.SetThrottle(20 * time.Millisecond)
+
+	if _, err := goodWait.Wait(); err != nil {
+		t.Errorf("returned: %v", err)
+	}
+	time.Sleep(2 * time.Second)
+	if _, err := goodWait.Wait(); err == nil {
+		t.Error("expected error but got nil")
+	}
+
 }

--- a/pkg/api/v1/projects/projects.go
+++ b/pkg/api/v1/projects/projects.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/SchwarzIT/community-stackit-go-client/internal/common"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/consts"
-	"github.com/SchwarzIT/community-stackit-go-client/pkg/retry"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/validate"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/wait"
 	"github.com/pkg/errors"
@@ -154,14 +153,7 @@ func (svc *ProjectService) Create(ctx context.Context, name, billingRef string, 
 
 // CreateAndWait wraps around `Create` and runs it with retry mechanism (which can be overridden by specifying a retry)
 // it returns a wait service - by running Do() the wait service will wait for the project to be in active state
-func (svc *ProjectService) CreateAndWait(ctx context.Context, name, billingRef string, roles []ProjectRole, r ...*retry.Retry) (Project, *wait.Wait, error) {
-	if len(r) == 0 {
-		r = append(r, retry.New())
-	}
-	if svc.Client.GetRetry() == nil {
-		svc.Client = svc.Client.WithRetry(r[0])
-	}
-
+func (svc *ProjectService) CreateAndWait(ctx context.Context, name, billingRef string, roles []ProjectRole) (Project, *wait.Wait, error) {
 	p, err := svc.Create(ctx, name, billingRef, roles...)
 	if err != nil {
 		return p, nil, err
@@ -308,14 +300,7 @@ func (svc *ProjectService) buildUpdateRequestBody(name, billingRef string) ([]by
 
 // UpdateAndWait wraps around `Update` and runs it with retry mechanism (which can be overridden by specifying a retry)
 // it returns a wait service - by running Do() the wait service will wait for the project to be in active state
-func (svc *ProjectService) UpdateAndWait(ctx context.Context, id, name, billingRef string, r ...*retry.Retry) (*wait.Wait, error) {
-	if len(r) == 0 {
-		r = append(r, retry.New())
-	}
-	if svc.Client.GetRetry() == nil {
-		svc.Client = svc.Client.WithRetry(r[0])
-	}
-
+func (svc *ProjectService) UpdateAndWait(ctx context.Context, id, name, billingRef string) (*wait.Wait, error) {
 	err := svc.Update(ctx, id, name, billingRef)
 	if err != nil {
 		return nil, err
@@ -356,14 +341,7 @@ func (svc *ProjectService) Delete(ctx context.Context, projectID string) error {
 
 // DeleteAndWait wraps around `Delete` and runs it with retry mechanism (which can be overridden by specifying a retry)
 // it returns a wait service - by running Do() the wait service will wait for the project to be deleted
-func (svc *ProjectService) DeleteAndWait(ctx context.Context, projectID string, r ...*retry.Retry) (*wait.Wait, error) {
-	if len(r) == 0 {
-		r = append(r, retry.New())
-	}
-	if svc.Client.GetRetry() == nil {
-		svc.Client = svc.Client.WithRetry(r[0])
-	}
-
+func (svc *ProjectService) DeleteAndWait(ctx context.Context, projectID string) (*wait.Wait, error) {
 	err := svc.Delete(ctx, projectID)
 	if err != nil {
 		return nil, err

--- a/pkg/api/v1/projects/projects.go
+++ b/pkg/api/v1/projects/projects.go
@@ -110,22 +110,23 @@ type ProjectsParentResBody struct {
 // Implementation
 
 // Create creates a new STACKIT project
+// it returns a wait handler - running Wait() will wait for the project to be active
 // See also https://api.stackit.schwarz/resource-management/openapi.v1.html#operation/post-organizations-organizationId-projects
-func (svc *ProjectService) Create(ctx context.Context, name, billingRef string, roles ...ProjectRole) (Project, error) {
+func (svc *ProjectService) Create(ctx context.Context, name, billingRef string, roles ...ProjectRole) (Project, *wait.Handler, error) {
 	if err := ValidateProjectCreationRoles(roles); err != nil {
-		return Project{}, validate.WrapError(err)
+		return Project{}, nil, validate.WrapError(err)
 	}
 	if err := validate.ProjectName(name); err != nil {
-		return Project{}, validate.WrapError(err)
+		return Project{}, nil, validate.WrapError(err)
 	}
 
 	if err := validate.BillingRef(billingRef); err != nil {
-		return Project{}, validate.WrapError(err)
+		return Project{}, nil, validate.WrapError(err)
 	}
 
 	body, err := svc.buildCreateRequestBody(name, billingRef, roles...)
 	if err != nil {
-		return Project{}, err
+		return Project{}, nil, err
 	}
 
 	req, err := svc.Client.Request(
@@ -135,28 +136,19 @@ func (svc *ProjectService) Create(ctx context.Context, name, billingRef string, 
 		body,
 	)
 	if err != nil {
-		return Project{}, err
+		return Project{}, nil, err
 	}
 
 	resBody := &ProjectsResBody{}
 	if _, err = svc.Client.Do(req, resBody); err != nil {
-		return Project{}, errors.Wrap(err, fmt.Sprintf("request was:\n%s", string(body)))
+		return Project{}, nil, errors.Wrap(err, fmt.Sprintf("request was:\n%s", string(body)))
 	}
 
-	return Project{
+	p := Project{
 		ID:               resBody.ProjectID,
 		Name:             resBody.Name,
 		BillingReference: resBody.Labels.BillingReference,
 		OrganizationID:   resBody.Parent.ID,
-	}, nil
-}
-
-// CreateAndWait wraps around `Create` and runs it with retry mechanism (which can be overridden by specifying a retry)
-// it returns a wait service - by running Do() the wait service will wait for the project to be in active state
-func (svc *ProjectService) CreateAndWait(ctx context.Context, name, billingRef string, roles []ProjectRole) (Project, *wait.Wait, error) {
-	p, err := svc.Create(ctx, name, billingRef, roles...)
-	if err != nil {
-		return p, nil, err
 	}
 
 	w := wait.New(func() (interface{}, bool, error) {
@@ -170,7 +162,7 @@ func (svc *ProjectService) CreateAndWait(ctx context.Context, name, billingRef s
 		return state, true, nil
 	})
 
-	return p, w, err
+	return p, w, nil
 }
 
 func (svc *ProjectService) buildCreateRequestBody(name, billingRef string, roles ...ProjectRole) ([]byte, error) {
@@ -298,31 +290,10 @@ func (svc *ProjectService) buildUpdateRequestBody(name, billingRef string) ([]by
 	})
 }
 
-// UpdateAndWait wraps around `Update` and runs it with retry mechanism (which can be overridden by specifying a retry)
-// it returns a wait service - by running Do() the wait service will wait for the project to be in active state
-func (svc *ProjectService) UpdateAndWait(ctx context.Context, id, name, billingRef string) (*wait.Wait, error) {
-	err := svc.Update(ctx, id, name, billingRef)
-	if err != nil {
-		return nil, err
-	}
-
-	w := wait.New(func() (interface{}, bool, error) {
-		state, err := svc.GetLifecycleState(ctx, id)
-		if err != nil {
-			return state, false, err
-		}
-		if state != consts.PROJECT_STATUS_ACTIVE {
-			return state, false, nil
-		}
-		return state, true, nil
-	})
-
-	return w, err
-}
-
 // Delete deletes a project by ID
+// it returns a wait handler - running Wait() will wait for the project to be deleted
 // See also https://api.stackit.schwarz/resource-management/openapi.v1.html#operation/delete-projects-projectId
-func (svc *ProjectService) Delete(ctx context.Context, projectID string) error {
+func (svc *ProjectService) Delete(ctx context.Context, projectID string) (*wait.Handler, error) {
 	req, err := svc.Client.Request(
 		ctx,
 		http.MethodDelete,
@@ -330,20 +301,10 @@ func (svc *ProjectService) Delete(ctx context.Context, projectID string) error {
 		nil,
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if _, err = svc.Client.Do(req, nil); err != nil {
-		return err
-	}
-	return nil
-}
-
-// DeleteAndWait wraps around `Delete` and runs it with retry mechanism (which can be overridden by specifying a retry)
-// it returns a wait service - by running Do() the wait service will wait for the project to be deleted
-func (svc *ProjectService) DeleteAndWait(ctx context.Context, projectID string) (*wait.Wait, error) {
-	err := svc.Delete(ctx, projectID)
-	if err != nil {
 		return nil, err
 	}
 
@@ -355,5 +316,5 @@ func (svc *ProjectService) DeleteAndWait(ctx context.Context, projectID string) 
 		return state, false, nil
 	})
 
-	return w, err
+	return w, nil
 }

--- a/pkg/api/v1/projects/projects.go
+++ b/pkg/api/v1/projects/projects.go
@@ -166,15 +166,15 @@ func (svc *ProjectService) CreateAndWait(ctx context.Context, name, billingRef s
 		return p, nil, err
 	}
 
-	w := wait.New(func() (bool, error) {
+	w := wait.New(func() (interface{}, bool, error) {
 		state, err := svc.GetLifecycleState(ctx, p.ID)
 		if err != nil {
-			return false, err
+			return state, false, err
 		}
 		if state != consts.PROJECT_STATUS_ACTIVE {
-			return false, nil
+			return state, false, nil
 		}
-		return true, nil
+		return state, true, nil
 	})
 
 	return p, w, err

--- a/pkg/api/v1/projects/projects_test.go
+++ b/pkg/api/v1/projects/projects_test.go
@@ -142,6 +142,17 @@ func TestProjectsService_Create(t *testing.T) {
 		fmt.Fprint(w, string(b))
 	})
 
+	mux.HandleFunc("/resource-management/v1/projects/123", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `
+		{
+			"projectId": "123",
+			"lifecycleState": "ACTIVE",
+			"scope": "PUBLIC"
+		}
+		`)
+	})
+
 	role := p.ProjectRole{
 		Name: "project.owner",
 		Users: []p.ProjectRoleMember{
@@ -150,7 +161,7 @@ func TestProjectsService_Create(t *testing.T) {
 			},
 		},
 	}
-	got, _, err := projects.Create(context.Background(), "Fancy-new-project", "T-9876543B", role)
+	got, w, err := projects.Create(context.Background(), "Fancy-new-project", "T-9876543B", role)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,6 +175,10 @@ func TestProjectsService_Create(t *testing.T) {
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got = %v, want %v", got, want)
+	}
+
+	if _, err := w.Wait(); err != nil {
+		t.Error(err)
 	}
 }
 
@@ -209,9 +224,15 @@ func TestProjectsService_Delete(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	if _, err := projects.Delete(context.Background(), "abc"); err != nil {
+	w, err := projects.Delete(context.Background(), "abc")
+	if err != nil {
 		t.Errorf("delete project: %v", err)
 	}
+
+	if _, err := w.Wait(); err != nil {
+		t.Error(err)
+	}
+
 }
 
 func TestAccProjectsService_Delete(t *testing.T) {

--- a/pkg/api/v1/projects/projects_test.go
+++ b/pkg/api/v1/projects/projects_test.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/SchwarzIT/community-stackit-go-client"
+	client "github.com/SchwarzIT/community-stackit-go-client"
 	"github.com/SchwarzIT/community-stackit-go-client/internal/clients"
 	p "github.com/SchwarzIT/community-stackit-go-client/pkg/api/v1/projects"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/consts"

--- a/pkg/api/v1/projects/projects_test.go
+++ b/pkg/api/v1/projects/projects_test.go
@@ -150,7 +150,7 @@ func TestProjectsService_Create(t *testing.T) {
 			},
 		},
 	}
-	got, err := projects.Create(context.Background(), "Fancy-new-project", "T-9876543B", role)
+	got, _, err := projects.Create(context.Background(), "Fancy-new-project", "T-9876543B", role)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,7 +190,7 @@ func TestAccProjectsService_Create(t *testing.T) {
 			},
 		},
 	}
-	got, err := projects.Create(context.Background(), want.Name, want.BillingReference, role)
+	got, _, err := projects.Create(context.Background(), want.Name, want.BillingReference, role)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestProjectsService_Delete(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	if err := projects.Delete(context.Background(), "abc"); err != nil {
+	if _, err := projects.Delete(context.Background(), "abc"); err != nil {
 		t.Errorf("delete project: %v", err)
 	}
 }
@@ -223,7 +223,7 @@ func TestAccProjectsService_Delete(t *testing.T) {
 		t.Error(err)
 	}
 	projects := p.New(c)
-	if err := projects.Delete(context.Background(), "0d3a2fb9-1472-4284-9655-d7aae2cd5bd5"); err != nil {
+	if _, err := projects.Delete(context.Background(), "0d3a2fb9-1472-4284-9655-d7aae2cd5bd5"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/retry/is_retryable.go
+++ b/pkg/retry/is_retryable.go
@@ -14,24 +14,24 @@ const (
 )
 
 // IsRetryable is the config struct
-type IsRetryable struct {
+type isRetryable struct {
 	fnList []func(err error) bool
 }
 
 // SetIsRetryable sets functions that determin if an error can be retried or not
 func (c *Retry) SetIsRetryable(f ...func(err error) bool) *Retry {
-	return c.withConfig(&IsRetryable{
+	return c.withConfig(&isRetryable{
 		fnList: f,
 	})
 }
 
-var _ = Config(&IsRetryable{})
+var _ = Config(&isRetryable{})
 
-func (c *IsRetryable) String() string {
+func (c *isRetryable) String() string {
 	return CONFIG_IS_RETRYABLE
 }
 
-func (c *IsRetryable) Value() interface{} {
+func (c *isRetryable) Value() interface{} {
 	return c.fnList
 }
 

--- a/pkg/retry/is_retryable.go
+++ b/pkg/retry/is_retryable.go
@@ -46,7 +46,8 @@ func IsRetryableDefault(err error) bool {
 		return strings.Contains(err.Error(), ERR_NO_SUCH_HOST)
 	}
 
-	if strings.Contains(err.Error(), http.StatusText(http.StatusUnauthorized)) {
+	if strings.Contains(err.Error(), http.StatusText(http.StatusUnauthorized)) ||
+		strings.Contains(err.Error(), http.StatusText(http.StatusNotFound)) {
 		return false
 	}
 

--- a/pkg/retry/is_retryable_test.go
+++ b/pkg/retry/is_retryable_test.go
@@ -14,7 +14,7 @@ func GetFunctionName(i interface{}) string {
 
 func TestRetry_SetIsRetryable(t *testing.T) {
 	r := New()
-	r.IsRetryableFns = []func(err error) bool{IsRetryableNoOp}
+	r.isRetryableFns = []func(err error) bool{IsRetryableNoOp}
 
 	type args struct {
 		f []func(err error) bool
@@ -30,13 +30,13 @@ func TestRetry_SetIsRetryable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New()
 			got := c.SetIsRetryable(tt.args.f...)
-			if len(got.IsRetryableFns) != len(r.IsRetryableFns) {
+			if len(got.isRetryableFns) != len(r.isRetryableFns) {
 				t.Error("wrong lengths")
 				return
 			}
-			for k, v := range got.IsRetryableFns {
-				if GetFunctionName(r.IsRetryableFns[k]) != GetFunctionName(v) {
-					t.Errorf("%s != %s", GetFunctionName(r.IsRetryableFns[k]), GetFunctionName(v))
+			for k, v := range got.isRetryableFns {
+				if GetFunctionName(r.isRetryableFns[k]) != GetFunctionName(v) {
+					t.Errorf("%s != %s", GetFunctionName(r.isRetryableFns[k]), GetFunctionName(v))
 					return
 				}
 			}

--- a/pkg/retry/max_retries.go
+++ b/pkg/retry/max_retries.go
@@ -5,26 +5,26 @@ const (
 	CONFIG_MAX_RETRIES = "MaxRetries"
 )
 
-// MaxRetries is the config struct
-type MaxRetries struct {
+// maxRetries is the config struct
+type maxRetries struct {
 	Retries *int
 }
 
 // SetMaxRetries sets the maximum retries
 func (c *Retry) SetMaxRetries(r int) *Retry {
-	return c.withConfig(&MaxRetries{
+	return c.withConfig(&maxRetries{
 		Retries: &r,
 	})
 }
 
-var _ = Config(&Timeout{})
+var _ = Config(&maxRetries{})
 
 // String returns the config name
-func (c *MaxRetries) String() string {
+func (c *maxRetries) String() string {
 	return CONFIG_MAX_RETRIES
 }
 
 // Value return the value
-func (c *MaxRetries) Value() interface{} {
+func (c *maxRetries) Value() interface{} {
 	return c.Retries
 }

--- a/pkg/retry/max_retries_test.go
+++ b/pkg/retry/max_retries_test.go
@@ -8,7 +8,7 @@ import (
 func TestRetry_SetMaxRetries(t *testing.T) {
 	r := New()
 	five := 5
-	r.MaxRetries = &five
+	r.maxRetries = &five
 	type args struct {
 		r int
 	}
@@ -22,8 +22,8 @@ func TestRetry_SetMaxRetries(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New()
-			if got := c.SetMaxRetries(tt.args.r); !reflect.DeepEqual(*got.MaxRetries, *tt.want.MaxRetries) {
-				t.Errorf("Retry.SetMaxRetries() = %v, want %v", *got.MaxRetries, *tt.want.MaxRetries)
+			if got := c.SetMaxRetries(tt.args.r); !reflect.DeepEqual(*got.maxRetries, *tt.want.maxRetries) {
+				t.Errorf("Retry.SetMaxRetries() = %v, want %v", *got.maxRetries, *tt.want.maxRetries)
 			}
 		})
 	}

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -9,11 +9,11 @@ import (
 )
 
 type Retry struct {
-	timeout        time.Duration               // max duration
-	maxRetries     *int                        // max retries, when nil, there's no retry limit
-	throttle       time.Duration               // wait duration between calls
-	isRetryableFns []func(err error) bool      // functions to determine if error is retriable
-	untilFns       []func(*http.Response) bool // functions to the determine if the given response is the expected response
+	timeout        time.Duration          // max duration
+	maxRetries     *int                   // max retries, when nil, there's no retry limit
+	throttle       time.Duration          // wait duration between calls
+	isRetryableFns []func(err error) bool // functions to determine if error is retriable
+	untilFns       []UntilFn              // functions to the determine if the given response is the expected response
 }
 
 type Config interface {
@@ -44,7 +44,7 @@ func (c *Retry) withConfig(cfgs ...Config) *Retry {
 		case CONFIG_IS_RETRYABLE:
 			c.isRetryableFns = cfg.Value().([]func(err error) bool)
 		case CONFIG_UNTIL:
-			c.untilFns = cfg.Value().([]func(*http.Response) bool)
+			c.untilFns = cfg.Value().([]UntilFn)
 		}
 	}
 	return c
@@ -70,8 +70,11 @@ func (r *Retry) Do(req *http.Request, do func(*http.Request) (*http.Response, er
 
 	for {
 		res, maxRetries, retry, lastErr = r.doIteration(newReq, do, maxRetries)
-		if lastErr == nil && r.isFulfilled(res) {
-			return res, nil
+		if lastErr == nil {
+			fulfilled, err := r.isFulfilled(res)
+			if fulfilled || err != nil {
+				return res, err
+			}
 		}
 
 		if !retry {
@@ -121,12 +124,16 @@ func (r *Retry) doIteration(req *http.Request, do func(*http.Request) (*http.Res
 	return
 }
 
-// isFulfilled check if Until functions are all fulfilled
-func (r *Retry) isFulfilled(res *http.Response) bool {
+// isFulfilled check if Wait functions are all fulfilled
+func (r *Retry) isFulfilled(res *http.Response) (bool, error) {
 	for _, f := range r.untilFns {
-		if !f(res) {
-			return false
+		v, err := f(res)
+		if !v {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
 		}
 	}
-	return true
+	return true, nil
 }

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -9,11 +9,11 @@ import (
 )
 
 type Retry struct {
-	Timeout        time.Duration               // max duration
-	MaxRetries     *int                        // max retries, when nil, there's no retry limit
-	Throttle       time.Duration               // wait duration between calls
-	IsRetryableFns []func(err error) bool      // functions to determine if error is retriable
-	UntilFns       []func(*http.Response) bool // functions to the determine if the given response is the expected response
+	timeout        time.Duration               // max duration
+	maxRetries     *int                        // max retries, when nil, there's no retry limit
+	throttle       time.Duration               // wait duration between calls
+	isRetryableFns []func(err error) bool      // functions to determine if error is retriable
+	untilFns       []func(*http.Response) bool // functions to the determine if the given response is the expected response
 }
 
 type Config interface {
@@ -24,10 +24,10 @@ type Config interface {
 // New returns a new instance of Retry with default values
 func New() *Retry {
 	c := &Retry{
-		Timeout:        CONFIG_TIMEOUT_DEFAULT,
-		MaxRetries:     nil,
-		Throttle:       CONFIG_THROTTLE_DEFAULT,
-		IsRetryableFns: []func(err error) bool{IsRetryableDefault},
+		timeout:        CONFIG_TIMEOUT_DEFAULT,
+		maxRetries:     nil,
+		throttle:       CONFIG_THROTTLE_DEFAULT,
+		isRetryableFns: []func(err error) bool{IsRetryableDefault},
 	}
 	return c
 }
@@ -36,15 +36,15 @@ func (c *Retry) withConfig(cfgs ...Config) *Retry {
 	for _, cfg := range cfgs {
 		switch cfg.String() {
 		case CONFIG_TIMEOUT:
-			c.Timeout = cfg.Value().(time.Duration)
+			c.timeout = cfg.Value().(time.Duration)
 		case CONFIG_THROTTLE:
-			c.Throttle = cfg.Value().(time.Duration)
+			c.throttle = cfg.Value().(time.Duration)
 		case CONFIG_MAX_RETRIES:
-			c.MaxRetries = cfg.Value().(*int)
+			c.maxRetries = cfg.Value().(*int)
 		case CONFIG_IS_RETRYABLE:
-			c.IsRetryableFns = cfg.Value().([]func(err error) bool)
+			c.isRetryableFns = cfg.Value().([]func(err error) bool)
 		case CONFIG_UNTIL:
-			c.UntilFns = cfg.Value().([]func(*http.Response) bool)
+			c.untilFns = cfg.Value().([]func(*http.Response) bool)
 		}
 	}
 	return c
@@ -56,7 +56,7 @@ func (r *Retry) Do(req *http.Request, do func(*http.Request) (*http.Response, er
 	var res *http.Response
 	var retry bool
 
-	overall, cancel := context.WithTimeout(req.Context(), r.Timeout)
+	overall, cancel := context.WithTimeout(req.Context(), r.timeout)
 	defer cancel()
 
 	// set overall ctx in request
@@ -64,8 +64,8 @@ func (r *Retry) Do(req *http.Request, do func(*http.Request) (*http.Response, er
 
 	// clone max retries
 	maxRetries := -1
-	if r.MaxRetries != nil {
-		maxRetries = *r.MaxRetries
+	if r.maxRetries != nil {
+		maxRetries = *r.maxRetries
 	}
 
 	for {
@@ -79,7 +79,7 @@ func (r *Retry) Do(req *http.Request, do func(*http.Request) (*http.Response, er
 		}
 
 		// context timeout was chosen in order to support throttle = 0
-		tick, cancelTick := context.WithTimeout(context.Background(), r.Throttle)
+		tick, cancelTick := context.WithTimeout(context.Background(), r.throttle)
 		defer cancelTick()
 
 		select {
@@ -102,7 +102,7 @@ func (r *Retry) doIteration(req *http.Request, do func(*http.Request) (*http.Res
 	}
 
 	// check if error is retryable
-	for _, f := range r.IsRetryableFns {
+	for _, f := range r.isRetryableFns {
 		if !f(err) {
 			retry = false
 			return
@@ -123,7 +123,7 @@ func (r *Retry) doIteration(req *http.Request, do func(*http.Request) (*http.Res
 
 // isFulfilled check if Until functions are all fulfilled
 func (r *Retry) isFulfilled(res *http.Response) bool {
-	for _, f := range r.UntilFns {
+	for _, f := range r.untilFns {
 		if !f(res) {
 			return false
 		}

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -38,6 +38,7 @@ const (
 
 func TestClient_DoWithRetryThrottle(t *testing.T) {
 	c, mux, teardown, err := client.MockServer()
+	c.SetRetry(retry.New())
 	defer teardown()
 	if err != nil {
 		t.Errorf("error from mock.AuthServer: %s", err.Error())
@@ -74,6 +75,7 @@ func TestClient_DoWithRetryThrottle(t *testing.T) {
 
 func TestClient_DoWithRetryNonRetryableError(t *testing.T) {
 	c, mux, teardown, err := client.MockServer()
+	c.SetRetry(retry.New())
 	defer teardown()
 	if err != nil {
 		t.Errorf("error from mock.AuthServer: %s", err.Error())
@@ -92,6 +94,7 @@ func TestClient_DoWithRetryNonRetryableError(t *testing.T) {
 
 func TestClient_DoWithRetryMaxRetries(t *testing.T) {
 	c, mux, teardown, err := client.MockServer()
+	c.SetRetry(retry.New())
 	defer teardown()
 	if err != nil {
 		t.Errorf("error from mock.AuthServer: %s", err.Error())
@@ -111,6 +114,7 @@ func TestClient_DoWithRetryMaxRetries(t *testing.T) {
 
 func TestClient_DoWithRetryTimeout(t *testing.T) {
 	c, mux, teardown, err := client.MockServer()
+	c.SetRetry(retry.New())
 	defer teardown()
 	if err != nil {
 		t.Errorf("error from mock.AuthServer: %s", err.Error())
@@ -136,6 +140,7 @@ func TestClient_DoWithRetryTimeout(t *testing.T) {
 
 func TestClient_DoWithUntil(t *testing.T) {
 	c, mux, teardown, err := client.MockServer()
+	c.SetRetry(retry.New())
 	defer teardown()
 	if err != nil {
 		t.Errorf("error from mock.AuthServer: %s", err.Error())

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -56,15 +56,14 @@ func TestClient_DoWithRetryThrottle(t *testing.T) {
 		}
 	})
 
-	nc := c.WithRetry(retry.New().SetThrottle(1 * time.Second))
-
-	req, _ := nc.Request(context.Background(), http.MethodGet, "/2s", nil)
+	c.Retry().SetThrottle(1 * time.Second)
+	req, _ := c.Request(context.Background(), http.MethodGet, "/2s", nil)
 
 	var got struct {
 		Status bool `json:"status"`
 	}
 
-	if _, err := nc.Do(req, &got); err != nil {
+	if _, err := c.Do(req, &got); err != nil {
 		t.Errorf("do request: %v", err)
 	}
 
@@ -85,9 +84,8 @@ func TestClient_DoWithRetryNonRetryableError(t *testing.T) {
 		w.WriteHeader(http.StatusBadRequest)
 	})
 
-	nc := c.WithRetry(retry.New())
-	req, _ := nc.Request(context.Background(), http.MethodGet, "/err", nil)
-	if _, err := nc.Do(req, nil); err == nil {
+	req, _ := c.Request(context.Background(), http.MethodGet, "/err", nil)
+	if _, err := c.Do(req, nil); err == nil {
 		t.Error("expected do request to return error but got nil instead")
 	}
 }
@@ -104,9 +102,9 @@ func TestClient_DoWithRetryMaxRetries(t *testing.T) {
 		w.WriteHeader(http.StatusLocked)
 	})
 
-	nc := c.WithRetry(retry.New().SetThrottle(1 * time.Second).SetMaxRetries(2))
-	req, _ := nc.Request(context.Background(), http.MethodGet, "/err", nil)
-	if _, err := nc.Do(req, nil); !strings.Contains(err.Error(), "reached max retries") {
+	c.Retry().SetThrottle(1 * time.Second).SetMaxRetries(2)
+	req, _ := c.Request(context.Background(), http.MethodGet, "/err", nil)
+	if _, err := c.Do(req, nil); !strings.Contains(err.Error(), "reached max retries") {
 		t.Errorf("expected do request to return max retries error but got %q instead", err)
 	}
 }
@@ -123,15 +121,15 @@ func TestClient_DoWithRetryTimeout(t *testing.T) {
 		w.WriteHeader(http.StatusLocked)
 	})
 
-	nc := c.WithRetry(retry.New().SetTimeout(5 * time.Second))
-	req, _ := nc.Request(context.Background(), http.MethodGet, "/err", nil)
-	if _, err := nc.Do(req, nil); !strings.Contains(err.Error(), "retry context timed out") && !strings.Contains(err.Error(), http.StatusText(http.StatusLocked)) {
+	c.Retry().SetTimeout(5 * time.Second)
+	req, _ := c.Request(context.Background(), http.MethodGet, "/err", nil)
+	if _, err := c.Do(req, nil); !strings.Contains(err.Error(), "retry context timed out") && !strings.Contains(err.Error(), http.StatusText(http.StatusLocked)) {
 		t.Errorf("expected do request to return retry context timed out error with locked error status but got '%v' instead", err)
 	}
 
-	nc = c.WithRetry(retry.New().SetTimeout(0 * time.Second))
-	req, _ = nc.Request(context.Background(), http.MethodGet, "/err", nil)
-	if _, err := nc.Do(req, nil); !strings.Contains(err.Error(), "retry context timed out") {
+	c.Retry().SetTimeout(0 * time.Second)
+	req, _ = c.Request(context.Background(), http.MethodGet, "/err", nil)
+	if _, err := c.Do(req, nil); !strings.Contains(err.Error(), "retry context timed out") {
 		t.Errorf("expected do request to return retry context timed out error but got '%v' instead", err)
 	}
 }
@@ -160,13 +158,13 @@ func TestClient_DoWithUntil(t *testing.T) {
 		Status bool `json:"status"`
 	}
 
-	nc := c.WithRetry(retry.New().SetThrottle(1 * time.Second).SetUntil(func(r *http.Response) (bool, error) {
+	c.Retry().SetThrottle(1 * time.Second).SetUntil(func(r *http.Response) (bool, error) {
 		return got.Status, nil
-	}))
+	})
 
-	req, _ := nc.Request(context.Background(), http.MethodGet, "/2s", nil)
+	req, _ := c.Request(context.Background(), http.MethodGet, "/2s", nil)
 
-	if _, err := nc.Do(req, &got); err != nil {
+	if _, err := c.Do(req, &got); err != nil {
 		t.Errorf("do request: %v", err)
 	}
 
@@ -174,13 +172,13 @@ func TestClient_DoWithUntil(t *testing.T) {
 		t.Errorf("received status = %v", got.Status)
 	}
 
-	nc = c.WithRetry(retry.New().SetThrottle(1 * time.Second).SetUntil(func(r *http.Response) (bool, error) {
+	c.Retry().SetThrottle(1 * time.Second).SetUntil(func(r *http.Response) (bool, error) {
 		return got.Status, errors.New("error")
-	}))
+	})
 
-	req, _ = nc.Request(context.Background(), http.MethodGet, "/2s", nil)
+	req, _ = c.Request(context.Background(), http.MethodGet, "/2s", nil)
 
-	if _, err := nc.Do(req, &got); err == nil {
+	if _, err := c.Do(req, &got); err == nil {
 		t.Errorf("expected an error")
 	}
 

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -22,10 +23,7 @@ func TestNew(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := retry.New()
-			if got.MaxRetries != tt.want.MaxRetries ||
-				got.Throttle != tt.want.Throttle ||
-				got.Timeout != tt.want.Timeout ||
-				len(got.IsRetryableFns) != len(tt.want.IsRetryableFns) {
+			if reflect.DeepEqual(got, tt.want) {
 				t.Error("one or more values don't match")
 			}
 		})

--- a/pkg/retry/throttle.go
+++ b/pkg/retry/throttle.go
@@ -5,7 +5,7 @@ import "time"
 const (
 	// timeout configuration constants
 	CONFIG_THROTTLE         = "Throttle"
-	CONFIG_THROTTLE_DEFAULT = 5 * time.Second
+	CONFIG_THROTTLE_DEFAULT = 1 * time.Second
 )
 
 // throttle is the config struct

--- a/pkg/retry/throttle.go
+++ b/pkg/retry/throttle.go
@@ -8,26 +8,26 @@ const (
 	CONFIG_THROTTLE_DEFAULT = 5 * time.Second
 )
 
-// Throttle is the config struct
-type Throttle struct {
+// throttle is the config struct
+type throttle struct {
 	Duration time.Duration
 }
 
 // SetThrottle sets the duration to wait between calls
 func (c *Retry) SetThrottle(d time.Duration) *Retry {
-	return c.withConfig(&Throttle{
+	return c.withConfig(&throttle{
 		Duration: d,
 	})
 }
 
-var _ = Config(&Throttle{})
+var _ = Config(&throttle{})
 
 // String return the name of the config
-func (c *Throttle) String() string {
+func (c *throttle) String() string {
 	return CONFIG_THROTTLE
 }
 
 // Value returns the defined value
-func (c *Throttle) Value() interface{} {
+func (c *throttle) Value() interface{} {
 	return c.Duration
 }

--- a/pkg/retry/throttle_test.go
+++ b/pkg/retry/throttle_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestRetry_SetThrottle(t *testing.T) {
 	r := New()
-	r.Throttle = time.Minute
+	r.throttle = time.Minute
 	type args struct {
 		d time.Duration
 	}
@@ -22,8 +22,8 @@ func TestRetry_SetThrottle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New()
-			if got := c.SetThrottle(tt.args.d); !reflect.DeepEqual(got.Throttle, tt.want.Throttle) {
-				t.Errorf("Retry.SetThrottle() = %v, want %v", got.Throttle, tt.want.Throttle)
+			if got := c.SetThrottle(tt.args.d); !reflect.DeepEqual(got.throttle, tt.want.throttle) {
+				t.Errorf("Retry.SetThrottle() = %v, want %v", got.throttle, tt.want.throttle)
 			}
 		})
 	}

--- a/pkg/retry/timeout.go
+++ b/pkg/retry/timeout.go
@@ -8,26 +8,26 @@ const (
 	CONFIG_TIMEOUT_DEFAULT = 60 * time.Minute
 )
 
-// Timeout is the config struct
-type Timeout struct {
+// timeout is the config struct
+type timeout struct {
 	Duration time.Duration
 }
 
 // SetTimeout sets the maximum run duration
 func (c *Retry) SetTimeout(d time.Duration) *Retry {
-	return c.withConfig(&Timeout{
+	return c.withConfig(&timeout{
 		Duration: d,
 	})
 }
 
-var _ = Config(&Timeout{})
+var _ = Config(&timeout{})
 
 // String return the name of the config
-func (c *Timeout) String() string {
+func (c *timeout) String() string {
 	return CONFIG_TIMEOUT
 }
 
 // Value returns the defined value
-func (c *Timeout) Value() interface{} {
+func (c *timeout) Value() interface{} {
 	return c.Duration
 }

--- a/pkg/retry/timeout.go
+++ b/pkg/retry/timeout.go
@@ -5,7 +5,7 @@ import "time"
 const (
 	// timeout configuration constants
 	CONFIG_TIMEOUT         = "Timeout"
-	CONFIG_TIMEOUT_DEFAULT = 10 * time.Minute
+	CONFIG_TIMEOUT_DEFAULT = 2 * time.Minute
 )
 
 // timeout is the config struct

--- a/pkg/retry/timeout.go
+++ b/pkg/retry/timeout.go
@@ -5,7 +5,7 @@ import "time"
 const (
 	// timeout configuration constants
 	CONFIG_TIMEOUT         = "Timeout"
-	CONFIG_TIMEOUT_DEFAULT = 60 * time.Minute
+	CONFIG_TIMEOUT_DEFAULT = 10 * time.Minute
 )
 
 // timeout is the config struct

--- a/pkg/retry/timeout_test.go
+++ b/pkg/retry/timeout_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestRetry_SetTimeout(t *testing.T) {
 	r := New()
-	r.Timeout = 1 * time.Minute
+	r.timeout = 1 * time.Minute
 	type args struct {
 		d time.Duration
 	}
@@ -22,8 +22,8 @@ func TestRetry_SetTimeout(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New()
-			if got := c.SetTimeout(tt.args.d); !reflect.DeepEqual(got.Timeout, tt.want.Timeout) {
-				t.Errorf("Retry.SetTimeout() = %v, want %v", got.Timeout, tt.want.Timeout)
+			if got := c.SetTimeout(tt.args.d); !reflect.DeepEqual(got.timeout, tt.want.timeout) {
+				t.Errorf("Retry.SetTimeout() = %v, want %v", got.timeout, tt.want.timeout)
 			}
 		})
 	}

--- a/pkg/retry/unti_test.go
+++ b/pkg/retry/unti_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestRetry_Until(t *testing.T) {
 	r := New()
-	r.UntilFns = []func(*http.Response) bool{noOp}
+	r.untilFns = []func(*http.Response) bool{noOp}
 
 	type args struct {
 		f []func(*http.Response) bool
@@ -23,13 +23,13 @@ func TestRetry_Until(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New()
 			got := c.Until(tt.args.f...)
-			if len(got.UntilFns) != len(r.UntilFns) {
+			if len(got.untilFns) != len(r.untilFns) {
 				t.Error("wrong lengths")
 				return
 			}
-			for k, v := range got.UntilFns {
-				if GetFunctionName(r.UntilFns[k]) != GetFunctionName(v) {
-					t.Errorf("%s != %s", GetFunctionName(r.UntilFns[k]), GetFunctionName(v))
+			for k, v := range got.untilFns {
+				if GetFunctionName(r.untilFns[k]) != GetFunctionName(v) {
+					t.Errorf("%s != %s", GetFunctionName(r.untilFns[k]), GetFunctionName(v))
 					return
 				}
 			}

--- a/pkg/retry/unti_test.go
+++ b/pkg/retry/unti_test.go
@@ -5,24 +5,25 @@ import (
 	"testing"
 )
 
-func TestRetry_Until(t *testing.T) {
+func TestRetry_Wait(t *testing.T) {
 	r := New()
-	r.untilFns = []func(*http.Response) bool{noOp}
+
+	r.untilFns = []UntilFn{noOp}
 
 	type args struct {
-		f []func(*http.Response) bool
+		f []UntilFn
 	}
 	tests := []struct {
 		name string
 		args args
 		want *Retry
 	}{
-		{"ok", args{[]func(*http.Response) bool{noOp}}, r},
+		{"ok", args{[]UntilFn{noOp}}, r},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New()
-			got := c.Until(tt.args.f...)
+			got := c.SetUntil(tt.args.f...)
 			if len(got.untilFns) != len(r.untilFns) {
 				t.Error("wrong lengths")
 				return
@@ -37,6 +38,6 @@ func TestRetry_Until(t *testing.T) {
 	}
 }
 
-func noOp(_ *http.Response) bool {
-	return true
+func noOp(_ *http.Response) (bool, error) {
+	return true, nil
 }

--- a/pkg/retry/until.go
+++ b/pkg/retry/until.go
@@ -7,25 +7,25 @@ const (
 	CONFIG_UNTIL = "UntilFns"
 )
 
-// UntilFns is the config struct
-type UntilFns struct {
+// untilFns is the config struct
+type untilFns struct {
 	fnList []func(*http.Response) bool
 }
 
 // Until sets functions that determin if the response given is the expected response
 // this functionality is useful, for example, when waiting for an API status to be ready
 func (c *Retry) Until(f ...func(*http.Response) bool) *Retry {
-	return c.withConfig(&UntilFns{
+	return c.withConfig(&untilFns{
 		fnList: f,
 	})
 }
 
-var _ = Config(&UntilFns{})
+var _ = Config(&untilFns{})
 
-func (c *UntilFns) String() string {
+func (c *untilFns) String() string {
 	return CONFIG_UNTIL
 }
 
-func (c *UntilFns) Value() interface{} {
+func (c *untilFns) Value() interface{} {
 	return c.fnList
 }

--- a/pkg/retry/until.go
+++ b/pkg/retry/until.go
@@ -3,29 +3,31 @@ package retry
 import "net/http"
 
 const (
-	// Until configuration constants
-	CONFIG_UNTIL = "UntilFns"
+	// Wait configuration constants
+	CONFIG_UNTIL = "Until"
 )
 
-// untilFns is the config struct
-type untilFns struct {
-	fnList []func(*http.Response) bool
+type UntilFn func(*http.Response) (bool, error)
+
+// until is the config struct
+type until struct {
+	fnList []UntilFn
 }
 
-// Until sets functions that determin if the response given is the expected response
+// SetUntil sets functions that determin if the response given is the expected response
 // this functionality is useful, for example, when waiting for an API status to be ready
-func (c *Retry) Until(f ...func(*http.Response) bool) *Retry {
-	return c.withConfig(&untilFns{
+func (c *Retry) SetUntil(f ...UntilFn) *Retry {
+	return c.withConfig(&until{
 		fnList: f,
 	})
 }
 
-var _ = Config(&untilFns{})
+var _ = Config(&until{})
 
-func (c *untilFns) String() string {
+func (c *until) String() string {
 	return CONFIG_UNTIL
 }
 
-func (c *untilFns) Value() interface{} {
+func (c *until) Value() interface{} {
 	return c.fnList
 }

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -1,0 +1,52 @@
+package wait
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type WaitFn func() (done bool, err error)
+
+type Wait struct {
+	fn       WaitFn
+	throttle time.Duration
+}
+
+// New creates a new Wait instance
+func New(f WaitFn) *Wait {
+	return &Wait{
+		fn:       f,
+		throttle: 5 * time.Second,
+	}
+}
+
+// SetThrottle sets the duration between func triggerring
+func (w *Wait) SetThrottle(d time.Duration) *Wait {
+	w.throttle = d
+	return w
+}
+
+// Do starts the wait until there's an error or wait is done
+func (w *Wait) Run(timeout time.Duration) (done bool, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	for {
+		done, err = w.fn()
+		if err != nil || done {
+			return
+		}
+
+		// context timeout was chosen in order to support throttle = 0
+		tick, cancelTick := context.WithTimeout(context.Background(), w.throttle)
+		defer cancelTick()
+
+		select {
+		case <-tick.Done():
+			// continue
+		case <-ctx.Done():
+			return false, errors.New("wait.Do() timed out")
+		}
+	}
+}

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -37,7 +37,8 @@ func (w *Wait) SetTimeout(d time.Duration) *Wait {
 }
 
 // Do starts the wait until there's an error or wait is done
-func (w *Wait) Run() (res interface{}, done bool, err error) {
+func (w *Wait) Run() (res interface{}, err error) {
+	var done bool
 	ctx, cancel := context.WithTimeout(context.Background(), w.timeout)
 	defer cancel()
 	for {
@@ -54,7 +55,7 @@ func (w *Wait) Run() (res interface{}, done bool, err error) {
 		case <-tick.Done():
 			// continue
 		case <-ctx.Done():
-			return res, false, errors.New("wait.Do() timed out")
+			return res, errors.New("wait.Do() timed out")
 		}
 	}
 }

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -24,7 +24,7 @@ func New(f WaitFn) *Handler {
 	}
 }
 
-// SetThrottle sets the duration between func triggerring
+// SetThrottle sets the duration between func triggering
 func (w *Handler) SetThrottle(d time.Duration) *Handler {
 	w.throttle = d
 	return w

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -9,15 +9,15 @@ import (
 
 type WaitFn func() (res interface{}, done bool, err error)
 
-type Wait struct {
+type Handler struct {
 	fn       WaitFn
 	throttle time.Duration
 	timeout  time.Duration
 }
 
 // New creates a new Wait instance
-func New(f WaitFn) *Wait {
-	return &Wait{
+func New(f WaitFn) *Handler {
+	return &Handler{
 		fn:       f,
 		throttle: 5 * time.Second,
 		timeout:  30 * time.Minute,
@@ -25,19 +25,19 @@ func New(f WaitFn) *Wait {
 }
 
 // SetThrottle sets the duration between func triggerring
-func (w *Wait) SetThrottle(d time.Duration) *Wait {
+func (w *Handler) SetThrottle(d time.Duration) *Handler {
 	w.throttle = d
 	return w
 }
 
 // SetTimeout sets the duration for wait timeout
-func (w *Wait) SetTimeout(d time.Duration) *Wait {
+func (w *Handler) SetTimeout(d time.Duration) *Handler {
 	w.timeout = d
 	return w
 }
 
 // Do starts the wait until there's an error or wait is done
-func (w *Wait) Run() (res interface{}, err error) {
+func (w *Handler) Wait() (res interface{}, err error) {
 	var done bool
 	ctx, cancel := context.WithTimeout(context.Background(), w.timeout)
 	defer cancel()

--- a/pkg/wait/wait_test.go
+++ b/pkg/wait/wait_test.go
@@ -1,0 +1,111 @@
+package wait
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestNew(t *testing.T) {
+	simple := func() (done bool, err error) { return true, nil }
+	type args struct {
+		f WaitFn
+	}
+	tests := []struct {
+		name string
+		args args
+		want *Wait
+	}{
+		{"ok", args{simple}, &Wait{fn: simple, throttle: 5 * time.Second}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New(tt.args.f); !reflect.DeepEqual(got.throttle, tt.want.throttle) {
+				t.Errorf("New() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWait_SetThrottle(t *testing.T) {
+	simple := func() (done bool, err error) { return true, nil }
+	f := &Wait{
+		fn:       simple,
+		throttle: 10 * time.Second,
+	}
+	type args struct {
+		d time.Duration
+	}
+	tests := []struct {
+		name string
+		args args
+		want *Wait
+	}{
+		{"ok", args{10 * time.Second}, f},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := New(simple)
+			if got := w.SetThrottle(tt.args.d); !reflect.DeepEqual(got.throttle, tt.want.throttle) {
+				t.Errorf("Wait.SetThrottle() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWait_Run(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	type fields struct {
+		fn       WaitFn
+		throttle time.Duration
+	}
+	type args struct {
+		timeout time.Duration
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		wantDone bool
+		wantErr  bool
+	}{
+		{"ok", fields{throttle: 1 * time.Second, fn: func() (done bool, err error) {
+			return true, nil
+		}}, args{1 * time.Hour}, true, false},
+
+		{"ok 2", fields{throttle: 1 * time.Second, fn: func() (done bool, err error) {
+			if ctx.Err() == nil {
+				return false, nil
+			}
+			return true, nil
+		}}, args{1 * time.Hour}, true, false},
+
+		{"err", fields{throttle: 1 * time.Second, fn: func() (done bool, err error) {
+			return true, errors.New("something happened")
+		}}, args{1 * time.Hour}, true, true},
+
+		{"timeout", fields{throttle: 1 * time.Second, fn: func() (done bool, err error) {
+			return false, nil
+		}}, args{1 * time.Second}, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &Wait{
+				fn:       tt.fields.fn,
+				throttle: tt.fields.throttle,
+			}
+			gotDone, err := w.Run(tt.args.timeout)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Wait.Run() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotDone != tt.wantDone {
+				t.Errorf("Wait.Run() = %v, want %v", gotDone, tt.wantDone)
+			}
+		})
+	}
+}

--- a/pkg/wait/wait_test.go
+++ b/pkg/wait/wait_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	simple := func() (done bool, err error) { return true, nil }
+	simple := func() (res interface{}, done bool, err error) { return nil, true, nil }
 	type args struct {
 		f WaitFn
 	}
@@ -30,7 +30,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestWait_SetThrottle(t *testing.T) {
-	simple := func() (done bool, err error) { return true, nil }
+	simple := func() (res interface{}, done bool, err error) { return nil, true, nil }
 	f := &Wait{
 		fn:       simple,
 		throttle: 10 * time.Second,
@@ -73,23 +73,23 @@ func TestWait_Run(t *testing.T) {
 		wantDone bool
 		wantErr  bool
 	}{
-		{"ok", fields{throttle: 1 * time.Second, fn: func() (done bool, err error) {
-			return true, nil
+		{"ok", fields{throttle: 1 * time.Second, fn: func() (res interface{}, done bool, err error) {
+			return nil, true, nil
 		}}, args{1 * time.Hour}, true, false},
 
-		{"ok 2", fields{throttle: 1 * time.Second, fn: func() (done bool, err error) {
+		{"ok 2", fields{throttle: 1 * time.Second, fn: func() (res interface{}, done bool, err error) {
 			if ctx.Err() == nil {
-				return false, nil
+				return nil, false, nil
 			}
-			return true, nil
+			return nil, true, nil
 		}}, args{1 * time.Hour}, true, false},
 
-		{"err", fields{throttle: 1 * time.Second, fn: func() (done bool, err error) {
-			return true, errors.New("something happened")
+		{"err", fields{throttle: 1 * time.Second, fn: func() (res interface{}, done bool, err error) {
+			return nil, true, errors.New("something happened")
 		}}, args{1 * time.Hour}, true, true},
 
-		{"timeout", fields{throttle: 1 * time.Second, fn: func() (done bool, err error) {
-			return false, nil
+		{"timeout", fields{throttle: 1 * time.Second, fn: func() (res interface{}, done bool, err error) {
+			return nil, false, nil
 		}}, args{1 * time.Second}, false, true},
 	}
 	for _, tt := range tests {
@@ -98,7 +98,7 @@ func TestWait_Run(t *testing.T) {
 				fn:       tt.fields.fn,
 				throttle: tt.fields.throttle,
 			}
-			gotDone, err := w.Run(tt.args.timeout)
+			_, gotDone, err := w.Run()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Wait.Run() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/wait/wait_test.go
+++ b/pkg/wait/wait_test.go
@@ -17,9 +17,9 @@ func TestNew(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want *Wait
+		want *Handler
 	}{
-		{"ok", args{simple}, &Wait{fn: simple, throttle: 5 * time.Second}},
+		{"ok", args{simple}, &Handler{fn: simple, throttle: 5 * time.Second}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -32,7 +32,7 @@ func TestNew(t *testing.T) {
 
 func TestWait_SetThrottle(t *testing.T) {
 	simple := func() (res interface{}, done bool, err error) { return nil, true, nil }
-	f := &Wait{
+	f := &Handler{
 		fn:       simple,
 		throttle: 10 * time.Second,
 	}
@@ -42,7 +42,7 @@ func TestWait_SetThrottle(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want *Wait
+		want *Handler
 	}{
 		{"ok", args{10 * time.Second}, f},
 	}
@@ -92,12 +92,12 @@ func TestWait_Run(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			w := &Wait{
+			w := &Handler{
 				fn:       tt.fields.fn,
 				throttle: tt.fields.throttle,
 				timeout:  tt.fields.timeout,
 			}
-			_, err := w.Run()
+			_, err := w.Wait()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Wait.Run() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -107,7 +107,7 @@ func TestWait_Run(t *testing.T) {
 }
 
 func TestWait_SetTimeout(t *testing.T) {
-	f := &Wait{
+	f := &Handler{
 		throttle: 5 * time.Second,
 		timeout:  5 * time.Hour,
 	}
@@ -123,13 +123,13 @@ func TestWait_SetTimeout(t *testing.T) {
 		name   string
 		fields fields
 		args   args
-		want   *Wait
+		want   *Handler
 	}{
 		{"ok", fields{timeout: 1 * time.Hour, throttle: 5 * time.Second}, args{d: 5 * time.Hour}, f},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			w := &Wait{
+			w := &Handler{
 				throttle: tt.fields.throttle,
 				timeout:  tt.fields.timeout,
 			}

--- a/pkg/wait/wait_test.go
+++ b/pkg/wait/wait_test.go
@@ -2,10 +2,11 @@ package wait
 
 import (
 	"context"
-	"errors"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 func TestNew(t *testing.T) {
@@ -62,49 +63,78 @@ func TestWait_Run(t *testing.T) {
 	type fields struct {
 		fn       WaitFn
 		throttle time.Duration
-	}
-	type args struct {
-		timeout time.Duration
+		timeout  time.Duration
 	}
 	tests := []struct {
 		name     string
 		fields   fields
-		args     args
 		wantDone bool
 		wantErr  bool
 	}{
-		{"ok", fields{throttle: 1 * time.Second, fn: func() (res interface{}, done bool, err error) {
+		{"ok", fields{throttle: 1 * time.Second, timeout: 1 * time.Hour, fn: func() (res interface{}, done bool, err error) {
 			return nil, true, nil
-		}}, args{1 * time.Hour}, true, false},
+		}}, true, false},
 
-		{"ok 2", fields{throttle: 1 * time.Second, fn: func() (res interface{}, done bool, err error) {
+		{"ok 2", fields{throttle: 1 * time.Second, timeout: 1 * time.Hour, fn: func() (res interface{}, done bool, err error) {
 			if ctx.Err() == nil {
 				return nil, false, nil
 			}
 			return nil, true, nil
-		}}, args{1 * time.Hour}, true, false},
+		}}, true, false},
 
-		{"err", fields{throttle: 1 * time.Second, fn: func() (res interface{}, done bool, err error) {
+		{"err", fields{throttle: 1 * time.Second, timeout: 1 * time.Hour, fn: func() (res interface{}, done bool, err error) {
 			return nil, true, errors.New("something happened")
-		}}, args{1 * time.Hour}, true, true},
+		}}, true, true},
 
-		{"timeout", fields{throttle: 1 * time.Second, fn: func() (res interface{}, done bool, err error) {
+		{"timeout", fields{throttle: 1 * time.Second, timeout: 1 * time.Second, fn: func() (res interface{}, done bool, err error) {
 			return nil, false, nil
-		}}, args{1 * time.Second}, false, true},
+		}}, false, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := &Wait{
 				fn:       tt.fields.fn,
 				throttle: tt.fields.throttle,
+				timeout:  tt.fields.timeout,
 			}
-			_, gotDone, err := w.Run()
+			_, err := w.Run()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Wait.Run() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if gotDone != tt.wantDone {
-				t.Errorf("Wait.Run() = %v, want %v", gotDone, tt.wantDone)
+		})
+	}
+}
+
+func TestWait_SetTimeout(t *testing.T) {
+	f := &Wait{
+		throttle: 5 * time.Second,
+		timeout:  5 * time.Hour,
+	}
+
+	type fields struct {
+		throttle time.Duration
+		timeout  time.Duration
+	}
+	type args struct {
+		d time.Duration
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *Wait
+	}{
+		{"ok", fields{timeout: 1 * time.Hour, throttle: 5 * time.Second}, args{d: 5 * time.Hour}, f},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &Wait{
+				throttle: tt.fields.throttle,
+				timeout:  tt.fields.timeout,
+			}
+			if got := w.SetTimeout(tt.args.d); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Wait.SetTimeout() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
- retry package has been modified & the way it's connected to the client has changed to [Possibly Breaking changes]
- wait package added
- Kubernetes project Create & Delete return wait functionality [Breaking change]
- Project creation / deletion returns wait functionality [Breaking change]