### PR TITLE
Add wait to bucket create and bucket delete (closes #19)

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -21,12 +21,13 @@ func main() {
 	projectID := "1234-56789-101112"
 	bucketName := "example"
 
-	w, err := c.ObjectStorage.Buckets.Create(context.TODO(), projectID, bucketName)
-	if _, err := w.Wait(); err != nil {
+	process, err := c.ObjectStorage.Buckets.Create(context.TODO(), projectID, bucketName)
+	if err != nil {
 		panic(err)
 	}
 
-	if err != nil {
+	// wait for bucket to be created
+	if _, err := process.Wait(); err != nil {
 		panic(err)
 	}
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -21,7 +21,11 @@ func main() {
 	projectID := "1234-56789-101112"
 	bucketName := "example"
 
-	err = c.ObjectStorage.Buckets.Create(context.TODO(), projectID, bucketName)
+	w, err := c.ObjectStorage.Buckets.Create(context.TODO(), projectID, bucketName)
+	if _, err := w.Wait(); err != nil {
+		panic(err)
+	}
+
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/api/v1/object-storage/buckets/bucket.go
+++ b/pkg/api/v1/object-storage/buckets/bucket.go
@@ -75,7 +75,9 @@ func (svc *ObjectStorageBucketsService) Get(ctx context.Context, projectID, buck
 	return
 }
 
-// Create creates a new bucket
+// Create creates a new bucket and returns a wait handler
+// which upon call to `Wait()` will wait until the bucket is successfully created
+// Wait() returns the created Bucket and error if it occurred
 // See also https://api.stackit.schwarz/object-storage-service/openapi.v1.html#operation/create_bucket_v1_project__projectId__bucket__bucketName__post
 func (svc *ObjectStorageBucketsService) Create(ctx context.Context, projectID, bucketName string) (w *wait.Handler, err error) {
 	if err = ValidateBucketName(bucketName); err != nil {
@@ -110,6 +112,8 @@ func (svc *ObjectStorageBucketsService) waitForCreation(ctx context.Context, pro
 }
 
 // Delete deletes a bucket
+// which upon call to `Wait()` will wait until the bucket is successfully deleted
+// Wait() returns an error if it occurred
 // See also https://api.stackit.schwarz/ske-service/openapi.v1.html#operation/SkeService_DeleteBucket
 func (svc *ObjectStorageBucketsService) Delete(ctx context.Context, projectID, bucketName string) (w *wait.Handler, err error) {
 	req, err := svc.Client.Request(ctx, http.MethodDelete, fmt.Sprintf(apiPath, projectID, bucketName), nil)

--- a/pkg/api/v1/object-storage/buckets/bucket.go
+++ b/pkg/api/v1/object-storage/buckets/bucket.go
@@ -92,11 +92,11 @@ func (svc *ObjectStorageBucketsService) Create(ctx context.Context, projectID, b
 		return
 	}
 
-	w = wait.New(waitForCreation(ctx, projectID, bucketName, svc))
+	w = wait.New(svc.waitForCreation(ctx, projectID, bucketName))
 	return
 }
 
-func waitForCreation(ctx context.Context, projectID string, bucketName string, svc *ObjectStorageBucketsService) wait.WaitFn {
+func (svc *ObjectStorageBucketsService) waitForCreation(ctx context.Context, projectID string, bucketName string) wait.WaitFn {
 	return func() (interface{}, bool, error) {
 		res, err := svc.Get(ctx, projectID, bucketName)
 		if err != nil {
@@ -120,11 +120,11 @@ func (svc *ObjectStorageBucketsService) Delete(ctx context.Context, projectID, b
 	if err != nil {
 		return
 	}
-	w = wait.New(waitForDeletion(ctx, projectID, bucketName, svc))
+	w = wait.New(svc.waitForDeletion(ctx, projectID, bucketName))
 	return w, err
 }
 
-func waitForDeletion(ctx context.Context, projectID string, bucketName string, svc *ObjectStorageBucketsService) wait.WaitFn {
+func (svc *ObjectStorageBucketsService) waitForDeletion(ctx context.Context, projectID string, bucketName string) wait.WaitFn {
 	return func() (interface{}, bool, error) {
 		res, err := svc.Get(ctx, projectID, bucketName)
 		if err != nil {

--- a/pkg/api/v1/object-storage/buckets/bucket_test.go
+++ b/pkg/api/v1/object-storage/buckets/bucket_test.go
@@ -164,7 +164,13 @@ func TestObjectStorageBucketsService_Create(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := s.Create(tt.args.ctx, tt.args.projectID, tt.args.bucketName); (err != nil) != tt.wantErr {
+			w, err := s.Create(tt.args.ctx, tt.args.projectID, tt.args.bucketName)
+			hasErr := err != nil
+			if !hasErr {
+				_, err = w.Wait()
+			}
+			hasErr = hasErr || err != nil
+			if hasErr != tt.wantErr {
 				t.Errorf("ObjectStorageBucketsService.Create() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -206,7 +212,13 @@ func TestObjectStorageBucketsService_Delete(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := s.Delete(tt.args.ctx, tt.args.projectID, tt.args.bucketName); (err != nil) != tt.wantErr {
+			w, err := s.Delete(tt.args.ctx, tt.args.projectID, tt.args.bucketName)
+			hasErr := err != nil
+			if !hasErr {
+				_, err = w.Wait()
+			}
+			hasErr = hasErr || err != nil
+			if hasErr != tt.wantErr {
 				t.Errorf("ObjectStorageBucketsService.Delete() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/api/v1/object-storage/buckets/bucket_test.go
+++ b/pkg/api/v1/object-storage/buckets/bucket_test.go
@@ -138,10 +138,6 @@ func TestObjectStorageBucketsService_Get(t *testing.T) {
 }
 
 func TestObjectStorageBucketsService_Create(t *testing.T) {
-	c, mux, teardown, _ := client.MockServer()
-	defer teardown()
-	s := objectstorage.New(c).Buckets
-
 	projectID := "5dae0612-f5b1-4615-b7ca-b18796aa7e78"
 	bucketName := "my-bucket"
 	ctx1, cancel1 := context.WithTimeout(context.Background(), 1*time.Second)
@@ -170,6 +166,10 @@ func TestObjectStorageBucketsService_Create(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			c, mux, teardown, _ := client.MockServer()
+			defer teardown()
+			s := objectstorage.New(c).Buckets
+
 			mux.HandleFunc(fmt.Sprintf(apiPath, projectID, bucketName), func(w http.ResponseWriter, r *http.Request) {
 				switch r.Method {
 				case http.MethodGet:
@@ -209,10 +209,6 @@ func TestObjectStorageBucketsService_Create(t *testing.T) {
 }
 
 func TestObjectStorageBucketsService_Delete(t *testing.T) {
-	c, mux, teardown, _ := client.MockServer()
-	defer teardown()
-	s := objectstorage.New(c).Buckets
-
 	projectID := "5dae0612-f5b1-4615-b7ca-b18796aa7e78"
 	bucketName := "my-bucket"
 	ctx1, cancel1 := context.WithTimeout(context.Background(), 1*time.Second)
@@ -240,6 +236,9 @@ func TestObjectStorageBucketsService_Delete(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			c, mux, teardown, _ := client.MockServer()
+			defer teardown()
+			s := objectstorage.New(c).Buckets
 			mux.HandleFunc(fmt.Sprintf(apiPath, projectID, bucketName), func(w http.ResponseWriter, r *http.Request) {
 				switch r.Method {
 				case http.MethodGet:


### PR DESCRIPTION
The wait handler logic retries on error in both cases. If this will get used more often, it might be worth it to extract a function taking the err and req as arguments.

I've only adapted the existing unit tests without adding new ones. If adding more unit tests is wanted, I imagine that [mpatch](github.com/undefinedlabs/go-mpatch) might be a good addition to simplify getting the different errors?