### PR TITLE
Introduce fix for breaking Observability API Changes on STACKIT

### DIFF
--- a/internal/config/argus/v1.0/argus.json
+++ b/internal/config/argus/v1.0/argus.json
@@ -1321,14 +1321,9 @@
             "title": "Instance",
             "type": "string"
           },
-          "jaegerTracesUrl": {
+          "jaegerHttpUrl": {
             "minLength": 1,
             "title": "Jaegertracesurl",
-            "type": "string"
-          },
-          "jaegerUiUrl": {
-            "minLength": 1,
-            "title": "Jaegeruiurl",
             "type": "string"
           },
           "logsPushUrl": {
@@ -1367,9 +1362,14 @@
             "title": "Name",
             "type": "string"
           },
-          "otlpTracesUrl": {
+          "otlpHttpTracesUrl": {
             "minLength": 1,
-            "title": "Otlptracesurl",
+            "title": "OtlpHttptracesurl",
+            "type": "string"
+          },
+          "otlpGrpcTracesUrl": {
+            "minLength": 1,
+            "title": "OtlpGrpctracesurl",
             "type": "string"
           },
           "plan": {

--- a/pkg/services/argus/v1.0/instances/instances.go
+++ b/pkg/services/argus/v1.0/instances/instances.go
@@ -108,8 +108,7 @@ type InstanceSensitiveData struct {
 	GrafanaPublicReadAccess bool      `json:"grafanaPublicReadAccess"`
 	GrafanaURL              string    `json:"grafanaUrl"`
 	Instance                string    `json:"instance"`
-	JaegerTracesURL         string    `json:"jaegerTracesUrl"`
-	JaegerUiURL             string    `json:"jaegerUiUrl"`
+	JaegerHttpURL           *string   `json:"jaegerHttpUrl,omitempty"`
 	LogsPushURL             string    `json:"logsPushUrl"`
 	LogsURL                 string    `json:"logsUrl"`
 	MetricsRetentionTime1h  int       `json:"metricsRetentionTime1h"`
@@ -117,7 +116,8 @@ type InstanceSensitiveData struct {
 	MetricsRetentionTimeRaw int       `json:"metricsRetentionTimeRaw"`
 	MetricsURL              string    `json:"metricsUrl"`
 	Name                    *string   `json:"name,omitempty"`
-	OtlpTracesURL           string    `json:"otlpTracesUrl"`
+	OtlpGrpcTracesURL       *string   `json:"otlpGrpcTracesUrl,omitempty"`
+	OtlpHttpTracesURL       *string   `json:"otlpHttpTracesUrl,omitempty"`
 	Plan                    PlanModel `json:"plan"`
 	PushMetricsURL          string    `json:"pushMetricsUrl"`
 	TargetsURL              string    `json:"targetsUrl"`


### PR DESCRIPTION
STACKIT removed without updating latest OpenAPI Spec

```
otlpTracesUrl
jaegerUiUrl
jaegerTracesUrl
```

and introduced:

```
otlpGrpcTracesUrl
otlpHttpTracesUrl
jaegerHttpUrl
```

This PR is to fix the Terraform Provider too.